### PR TITLE
[Reviewer: Andy] Only start processes once clearwater-infrastructure has run

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,3 +22,4 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-
 RUN /etc/init.d/clearwater-auto-config-docker restart
 RUN /etc/init.d/clearwater-infrastructure restart
 COPY clearwater-infrastructure.supervisord.conf /etc/supervisor/conf.d/clearwater-infrastructure.conf
+COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf

--- a/base/clearwater-group.supervisord.conf
+++ b/base/clearwater-group.supervisord.conf
@@ -1,0 +1,2 @@
+[group:clearwater-group]
+programs=

--- a/base/clearwater-infrastructure.supervisord.conf
+++ b/base/clearwater-infrastructure.supervisord.conf
@@ -1,3 +1,3 @@
 [program:clearwater-infrastructure]
-command=bash -c '/etc/init.d/clearwater-auto-config-docker start && /etc/init.d/clearwater-infrastructure start'
+command=bash -c '/etc/init.d/clearwater-auto-config-docker start && /etc/init.d/clearwater-infrastructure start && supervisorctl start clearwater-group:*'
 startsecs=0

--- a/bono/Dockerfile
+++ b/bono/Dockerfile
@@ -9,5 +9,6 @@ RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \0/g' -i /e
 
 COPY bono.supervisord.conf /etc/supervisor/conf.d/bono.conf
 COPY restund.supervisord.conf /etc/supervisor/conf.d/restund.conf
+COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf
 
 EXPOSE 3478 3478/udp 5058 5060 5060/udp 5062

--- a/bono/bono.supervisord.conf
+++ b/bono/bono.supervisord.conf
@@ -1,3 +1,4 @@
 [program:bono]
 command=/etc/init.d/bono run
+autostart=false
 autorestart=true

--- a/bono/clearwater-group.supervisord.conf
+++ b/bono/clearwater-group.supervisord.conf
@@ -1,0 +1,2 @@
+[group:clearwater-group]
+programs=bono,restund

--- a/bono/restund.supervisord.conf
+++ b/bono/restund.supervisord.conf
@@ -1,3 +1,4 @@
 [program:restund]
 command=/etc/init.d/restund run
+autostart=false
 autorestart=true

--- a/ellis/Dockerfile
+++ b/ellis/Dockerfile
@@ -8,5 +8,6 @@ RUN /etc/init.d/mysql start && /usr/share/clearwater/ellis/env/bin/python /usr/s
 COPY ellis.supervisord.conf /etc/supervisor/conf.d/ellis.conf
 COPY mysql.supervisord.conf /etc/supervisor/conf.d/mysql.conf
 COPY nginx.supervisord.conf /etc/supervisor/conf.d/nginx.conf
+COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf
 
 EXPOSE 80

--- a/ellis/clearwater-group.supervisord.conf
+++ b/ellis/clearwater-group.supervisord.conf
@@ -1,0 +1,2 @@
+[group:clearwater-group]
+programs=ellis,mysql,nginx

--- a/ellis/ellis.supervisord.conf
+++ b/ellis/ellis.supervisord.conf
@@ -1,3 +1,4 @@
 [program:ellis]
 command=/etc/init.d/ellis run
+autostart=false
 autorestart=true

--- a/ellis/mysql.supervisord.conf
+++ b/ellis/mysql.supervisord.conf
@@ -1,3 +1,4 @@
 [program:mysql]
 command=/usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/sbin/mysqld
+autostart=false
 autorestart=true

--- a/ellis/nginx.supervisord.conf
+++ b/ellis/nginx.supervisord.conf
@@ -1,3 +1,4 @@
 [program:nginx]
 command=/usr/sbin/nginx -g 'daemon off;'
+autostart=false
 autorestart=true

--- a/homer/Dockerfile
+++ b/homer/Dockerfile
@@ -8,5 +8,6 @@ RUN /etc/init.d/cassandra start && apt-get update && DEBIAN_FRONTEND=noninteract
 COPY cassandra.supervisord.conf /etc/supervisor/conf.d/cassandra.conf
 COPY homer.supervisord.conf /etc/supervisor/conf.d/homer.conf
 COPY nginx.supervisord.conf /etc/supervisor/conf.d/nginx.conf
+COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf
 
 EXPOSE 7888

--- a/homer/cassandra.supervisord.conf
+++ b/homer/cassandra.supervisord.conf
@@ -1,3 +1,4 @@
 [program:cassandra]
 command=/usr/sbin/cassandra -f
+autostart=false
 autorestart=true

--- a/homer/clearwater-group.supervisord.conf
+++ b/homer/clearwater-group.supervisord.conf
@@ -1,0 +1,2 @@
+[group:clearwater-group]
+programs=cassandra,homer,nginx

--- a/homer/homer.supervisord.conf
+++ b/homer/homer.supervisord.conf
@@ -1,3 +1,4 @@
 [program:homer]
 command=/etc/init.d/homer run
+autostart=false
 autorestart=true

--- a/homer/nginx.supervisord.conf
+++ b/homer/nginx.supervisord.conf
@@ -1,3 +1,4 @@
 [program:nginx]
 command=/usr/sbin/nginx -g 'daemon off;'
+autostart=false
 autorestart=true

--- a/homestead/Dockerfile
+++ b/homestead/Dockerfile
@@ -10,5 +10,6 @@ RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \1/g' -i /e
 COPY cassandra.supervisord.conf /etc/supervisor/conf.d/cassandra.conf
 COPY homestead.supervisord.conf /etc/supervisor/conf.d/homestead.conf
 COPY nginx.supervisord.conf /etc/supervisor/conf.d/nginx.conf
+COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf
 
 EXPOSE 8888 8889

--- a/homestead/cassandra.supervisord.conf
+++ b/homestead/cassandra.supervisord.conf
@@ -1,3 +1,4 @@
 [program:cassandra]
 command=/usr/sbin/cassandra -f
+autostart=false
 autorestart=true

--- a/homestead/clearwater-group.supervisord.conf
+++ b/homestead/clearwater-group.supervisord.conf
@@ -1,0 +1,2 @@
+[group:clearwater-group]
+programs=cassandra,homestead,homestead-prov,nginx

--- a/homestead/homestead.supervisord.conf
+++ b/homestead/homestead.supervisord.conf
@@ -1,9 +1,11 @@
 [program:homestead]
 command=/etc/init.d/homestead run
+autostart=false
 autorestart=true
 # homestead kills itself if it can't talk to local cassandra - give it a few retries
 startretries=10
 
 [program:homestead-prov]
 command=/etc/init.d/homestead-prov run
+autostart=false
 autorestart=true

--- a/homestead/nginx.supervisord.conf
+++ b/homestead/nginx.supervisord.conf
@@ -1,3 +1,4 @@
 [program:nginx]
 command=/usr/sbin/nginx -g 'daemon off;'
+autostart=false
 autorestart=true

--- a/ralf/Dockerfile
+++ b/ralf/Dockerfile
@@ -7,5 +7,6 @@ RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \0/g' -i /e
 COPY chronos.supervisord.conf /etc/supervisor/conf.d/chronos.conf
 COPY memcached.supervisord.conf /etc/supervisor/conf.d/memcached.conf
 COPY ralf.supervisord.conf /etc/supervisor/conf.d/ralf.conf
+COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf
 
 EXPOSE 10888

--- a/ralf/chronos.supervisord.conf
+++ b/ralf/chronos.supervisord.conf
@@ -1,3 +1,4 @@
 [program:chronos]
 command=/etc/init.d/chronos run
+autostart=false
 autorestart=true

--- a/ralf/clearwater-group.supervisord.conf
+++ b/ralf/clearwater-group.supervisord.conf
@@ -1,0 +1,2 @@
+[group:clearwater-group]
+programs=chronos,memcached,ralf

--- a/ralf/memcached.supervisord.conf
+++ b/ralf/memcached.supervisord.conf
@@ -1,3 +1,4 @@
 [program:memcached]
 command=/usr/bin/memcached -v -e 'ignore_vbucket=true;cache_size=512000000' -p 11211 -u memcache -c 4096
+autostart=false
 autorestart=true

--- a/ralf/ralf.supervisord.conf
+++ b/ralf/ralf.supervisord.conf
@@ -1,3 +1,4 @@
 [program:ralf]
 command=/etc/init.d/ralf run
+autostart=false
 autorestart=true

--- a/sprout/Dockerfile
+++ b/sprout/Dockerfile
@@ -7,5 +7,6 @@ RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \0/g' -i /e
 COPY chronos.supervisord.conf /etc/supervisor/conf.d/chronos.conf
 COPY memcached.supervisord.conf /etc/supervisor/conf.d/memcached.conf
 COPY sprout.supervisord.conf /etc/supervisor/conf.d/sprout.conf
+COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf
 
 EXPOSE 5052 5054

--- a/sprout/chronos.supervisord.conf
+++ b/sprout/chronos.supervisord.conf
@@ -1,3 +1,4 @@
 [program:chronos]
 command=/etc/init.d/chronos run
+autostart=false
 autorestart=true

--- a/sprout/clearwater-group.supervisord.conf
+++ b/sprout/clearwater-group.supervisord.conf
@@ -1,0 +1,2 @@
+[group:clearwater-group]
+programs=chronos,memcached,sprout

--- a/sprout/memcached.supervisord.conf
+++ b/sprout/memcached.supervisord.conf
@@ -1,3 +1,4 @@
 [program:memcached]
 command=/usr/bin/memcached -v -e 'ignore_vbucket=true;cache_size=512000000' -p 11211 -u memcache -c 4096
+autostart=false
 autorestart=true

--- a/sprout/sprout.supervisord.conf
+++ b/sprout/sprout.supervisord.conf
@@ -1,3 +1,4 @@
 [program:sprout]
 command=/etc/init.d/sprout run
+autostart=false
 autorestart=true


### PR DESCRIPTION
Andy,

Please can you review my fix to #10?  There are quite a lot of changes, but in summary I have
-   marked all Clearwater processes as `autostart=false`
-   created a new `clearwater-group` process group (in clearwater-group.supervisord.conf) that contains all Clearwater processes
-   changed the `clearwater-infrastructure` process to invoke `supervisorctl start clearwater-group:*` to start all processes in clearwater-group once `clearwater-infrastructure` has run.

I've tested live.

Thanks,

Matt
