### PR TITLE
[Reviewer: Matt] Move to the Docker Compose v2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ To prepare your system to deploy Clearwater manually, run:
 
 To start the Clearwater services, run:
 
-    sudo docker run -d --name homestead -p 22 clearwater/homestead
-    sudo docker run -d --name homer -p 22 clearwater/homer
-    sudo docker run -d --name ralf -p 22 clearwater/ralf
-    sudo docker run -d --name sprout -p 22 --link homestead:homestead --link homer:homer --link ralf:ralf clearwater/sprout
-    sudo docker run -d --name bono -p 22 -p 3478:3478 -p 3478:3478/udp -p 5060:5060 -p 5060:5060/udp -p 5062:5062 --link sprout:sprout clearwater/bono
-    sudo docker run -d --name ellis -p 22 -p 80:80 --link homestead:homestead --link homer:homer clearwater/ellis
+    sudo docker network create --driver bridge clearwater_nw
+    sudo docker run -d --net=clearwater_nw --name homestead -p 22 clearwater/homestead
+    sudo docker run -d --net=clearwater_nw --name homer -p 22 clearwater/homer
+    sudo docker run -d --net=clearwater_nw --name ralf -p 22 clearwater/ralf
+    sudo docker run -d --net=clearwater_nw --name sprout -p 22 clearwater/sprout
+    sudo docker run -d --net=clearwater_nw --name bono -p 22 -p 3478:3478 -p 3478:3478/udp -p 5060:5060 -p 5060:5060/udp -p 5062:5062 clearwater/bono
+    sudo docker run -d --net=clearwater_nw --name ellis -p 22 -p 80:80 clearwater/ellis
 
 ### Stopping Clearwater
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ To start the Clearwater services, run:
     sudo docker run -d --net=clearwater_nw --name bono -p 22 -p 3478:3478 -p 3478:3478/udp -p 5060:5060 -p 5060:5060/udp -p 5062:5062 clearwater/bono
     sudo docker run -d --net=clearwater_nw --name ellis -p 22 -p 80:80 clearwater/ellis
 
+The Clearwater Docker images use DNS for service discovery - they require, for example, that the name "ellis" should resolve to the Ellis container's IP address. In standard Docker, user-defined networks include [an embedded DNS server](https://docs.docker.com/engine/userguide/networking/dockernetworks/#docker-embedded-dns-server) which guarantees this (and this is why we create the clearwater_nw network) - and this type of DNS server is relatively common (for example, [Kubernetes provides something similar](http://kubernetes.io/docs/user-guide/services/#dns)).
+
 ### Stopping Clearwater
 
 To stop the Clearwater services, run:

--- a/minimal-distributed.yaml
+++ b/minimal-distributed.yaml
@@ -1,39 +1,42 @@
-bono:
-  build: bono
-  links:
-    - sprout
-  ports:
-    - 22
-    - "3478:3478"
-    - "3478:3478/udp"
-    - "5060:5060"
-    - "5060:5060/udp"
-    - "5062:5062"
-sprout:
-  build: sprout
-  links:
-    - homestead
-    - homer
-    - ralf
-  ports:
-    - 22
-homestead:
-  build: homestead
-  ports:
-    - 22
-homer:
-  build: homer
-  ports:
-    - 22
-ralf:
-  build: ralf
-  ports:
-    - 22
-ellis:
-  build: ellis
-  links:
-    - homestead
-    - homer
-  ports:
-    - 22
-    - "80:80"
+version: '2'
+services:
+  bono:
+    build: bono
+    links:
+      - sprout
+    ports:
+      - 22
+      - "3478:3478"
+      - "3478:3478/udp"
+      - "5060:5060"
+      - "5060:5060/udp"
+      - "5062:5062"
+  sprout:
+    build: sprout
+    links:
+      - homestead
+      - homer
+      - ralf
+    ports:
+      - 22
+  homestead:
+    build: homestead
+    ports:
+      - 22
+  homer:
+    build: homer
+    ports:
+      - 22
+  ralf:
+    build: ralf
+    ports:
+      - 22
+  ellis:
+    build: ellis
+    links:
+      - homestead
+      - homer
+    ports:
+      - 22
+      - "80:80"
+


### PR DESCRIPTION
While working on the etcd stuff, I noticed that Docker links are [described as "legacy"](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/), and the preferred way to do this is with new-style Docker networks and the internal DNS server. I've moved to use this, and version 2 of the Compose API, rather than doing throwaway work by adding more stuff based on a deprecated version of the API. I think it makes things look simpler, too.

I've tested with Compose - I'll test the updated manual instructions before merging.
