### PR TITLE
[Reviewer: Matt] Add etcd and monit into Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To prepare your system to deploy Clearwater manually, run:
 To start the Clearwater services, run:
 
     sudo docker network create --driver bridge clearwater_nw
+    sudo docker run -d --net=clearwater_nw --name etcd quay.io/coreos/etcd:v2.2.5 -name etcd0 -advertise-client-urls http://etcd:2379,http://etcd:4001 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls http://etcd:2380 -listen-peer-urls http://0.0.0.0:2380  -initial-cluster etcd0=http://etcd:2380 -initial-cluster-state new
     sudo docker run -d --net=clearwater_nw --name homestead -p 22 clearwater/homestead
     sudo docker run -d --net=clearwater_nw --name homer -p 22 clearwater/homer
     sudo docker run -d --net=clearwater_nw --name ralf -p 22 clearwater/ralf

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,7 +18,7 @@ RUN sed -e 's/\#\(precedence ::ffff:0:0\/96  100\)/\1/g' -i /etc/gai.conf
 
 RUN echo deb http://repo.cw-ngv.com/stable binary/ > /etc/apt/sources.list.d/clearwater.list
 RUN curl -L http://repo.cw-ngv.com/repo_key | apt-key add -
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes clearwater-infrastructure clearwater-auto-config-docker
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes clearwater-infrastructure clearwater-auto-config-docker clearwater-management
 RUN /etc/init.d/clearwater-auto-config-docker restart
 RUN /etc/init.d/clearwater-infrastructure restart
 COPY clearwater-infrastructure.supervisord.conf /etc/supervisor/conf.d/clearwater-infrastructure.conf

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,5 +22,4 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-
 RUN /etc/init.d/clearwater-auto-config-docker restart
 RUN /etc/init.d/clearwater-infrastructure restart
 COPY clearwater-infrastructure.supervisord.conf /etc/supervisor/conf.d/clearwater-infrastructure.conf
-COPY monit.supervisord.conf /etc/supervisor/conf.d/monit.conf
 COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,4 +22,5 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-
 RUN /etc/init.d/clearwater-auto-config-docker restart
 RUN /etc/init.d/clearwater-infrastructure restart
 COPY clearwater-infrastructure.supervisord.conf /etc/supervisor/conf.d/clearwater-infrastructure.conf
+COPY monit.supervisord.conf /etc/supervisor/conf.d/monit.conf
 COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,7 +16,7 @@ ENV LC_ALL en_US.UTF-8
 COPY sysctl /sbin/sysctl
 RUN sed -e 's/\#\(precedence ::ffff:0:0\/96  100\)/\1/g' -i /etc/gai.conf
 
-RUN echo deb http://repo.cw-ngv.com/archive/repo92 binary/ > /etc/apt/sources.list.d/clearwater.list
+RUN echo deb http://repo.cw-ngv.com/stable binary/ > /etc/apt/sources.list.d/clearwater.list
 RUN curl -L http://repo.cw-ngv.com/repo_key | apt-key add -
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes clearwater-infrastructure clearwater-auto-config-docker clearwater-management
 RUN /etc/init.d/clearwater-auto-config-docker restart

--- a/base/clearwater-infrastructure.supervisord.conf
+++ b/base/clearwater-infrastructure.supervisord.conf
@@ -1,3 +1,3 @@
 [program:clearwater-infrastructure]
-command=bash -c '/etc/init.d/clearwater-auto-config-docker start && /etc/init.d/clearwater-infrastructure start && supervisorctl start clearwater-group:*'
+command=bash -c '/etc/init.d/clearwater-auto-config-docker start && /etc/init.d/clearwater-infrastructure start && /etc/init.d/clearwater-etcd start && /etc/init.d/clearwater-cluster-manager start && supervisorctl start clearwater-group:*'
 startsecs=0

--- a/base/clearwater-infrastructure.supervisord.conf
+++ b/base/clearwater-infrastructure.supervisord.conf
@@ -1,3 +1,3 @@
 [program:clearwater-infrastructure]
-command=bash -c '/etc/init.d/clearwater-auto-config-docker start && /etc/init.d/clearwater-infrastructure start'
+command=bash -c '/etc/init.d/clearwater-auto-config-docker start && /etc/init.d/clearwater-infrastructure start && /etc/init.d/clearwater-etcd start && /etc/init.d/clearwater-cluster-manager start && supervisorctl start clearwater-group:*'
 startsecs=0

--- a/base/clearwater-infrastructure.supervisord.conf
+++ b/base/clearwater-infrastructure.supervisord.conf
@@ -1,3 +1,3 @@
 [program:clearwater-infrastructure]
-command=bash -c '/etc/init.d/clearwater-auto-config-docker start && /etc/init.d/clearwater-infrastructure start && /etc/init.d/clearwater-etcd start && /etc/init.d/clearwater-cluster-manager start && supervisorctl start clearwater-group:*'
+command=bash -c '/etc/init.d/clearwater-auto-config-docker start && /etc/init.d/clearwater-infrastructure start'
 startsecs=0

--- a/base/monit.supervisord.conf
+++ b/base/monit.supervisord.conf
@@ -1,0 +1,5 @@
+[program:monit]
+command=/usr/bin/monit -I -c /etc/monit/monitrc
+autostart=true
+autorestart=true
+startretries=10

--- a/base/monit.supervisord.conf
+++ b/base/monit.supervisord.conf
@@ -1,5 +1,0 @@
-[program:monit]
-command=/usr/bin/monit -I -c /etc/monit/monitrc
-autostart=true
-autorestart=true
-startretries=10

--- a/homer/cassandra.supervisord.conf
+++ b/homer/cassandra.supervisord.conf
@@ -1,4 +1,6 @@
 [program:cassandra]
 command=/usr/sbin/cassandra -f
 autostart=false
+# Cassandra won't start until the cluster manager runs - retry until that happens
+startretries=5000
 autorestart=true

--- a/homer/homer.supervisord.conf
+++ b/homer/homer.supervisord.conf
@@ -2,3 +2,4 @@
 command=/etc/init.d/homer run
 autostart=false
 autorestart=true
+startretries=5000

--- a/homestead/cassandra.supervisord.conf
+++ b/homestead/cassandra.supervisord.conf
@@ -1,4 +1,6 @@
 [program:cassandra]
 command=/usr/sbin/cassandra -f
 autostart=false
+# Cassandra won't start until the cluster manager runs - retry until that happens
+startretries=5000
 autorestart=true

--- a/homestead/homestead.supervisord.conf
+++ b/homestead/homestead.supervisord.conf
@@ -3,7 +3,7 @@ command=/etc/init.d/homestead run
 autostart=false
 autorestart=true
 # homestead kills itself if it can't talk to local cassandra - give it a few retries
-startretries=10
+startretries=5000
 
 [program:homestead-prov]
 command=/etc/init.d/homestead-prov run

--- a/minimal-distributed.yaml
+++ b/minimal-distributed.yaml
@@ -27,6 +27,11 @@ services:
       - homestead
       - homer
       - ralf
+    networks:
+      default:
+        aliases:
+          - scscf.sprout
+          - icscf.sprout
     ports:
       - 22
   homestead:

--- a/minimal-distributed.yaml
+++ b/minimal-distributed.yaml
@@ -1,5 +1,8 @@
 version: '2'
 services:
+  etcd:
+    image: quay.io/coreos/etcd:v2.2.5
+    command:  -name etcd0 -advertise-client-urls http://etcd:2379,http://etcd:4001 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls http://etcd:2380 -listen-peer-urls http://0.0.0.0:2380  -initial-cluster etcd0=http://etcd:2380 -initial-cluster-state new
   bono:
     build: bono
     links:

--- a/minimal-distributed.yaml
+++ b/minimal-distributed.yaml
@@ -2,7 +2,14 @@ version: '2'
 services:
   etcd:
     image: quay.io/coreos/etcd:v2.2.5
-    command:  -name etcd0 -advertise-client-urls http://etcd:2379,http://etcd:4001 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls http://etcd:2380 -listen-peer-urls http://0.0.0.0:2380  -initial-cluster etcd0=http://etcd:2380 -initial-cluster-state new
+    command: >
+      -name etcd0
+      -advertise-client-urls http://etcd:2379,http://etcd:4001
+      -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001
+      -initial-advertise-peer-urls http://etcd:2380
+      -listen-peer-urls http://0.0.0.0:2380
+      -initial-cluster etcd0=http://etcd:2380
+      -initial-cluster-state new
   bono:
     build: bono
     links:


### PR DESCRIPTION
As discussed, I've:
- installed clearwater-management on Docker images
- pointed the nodes at an external etcd (that code's in a clearwater-infrastructure PR I'm about to send), as this is a commonly-requested feature

I've also had to install monit, as our clustering code [assumes that monit exists](https://github.com/Metaswitch/clearwater-cassandra/blob/922bb48ddd5abb5bc9543ed1d82756492c79a043/clearwater-cassandra/usr/share/clearwater/clearwater-cluster-manager/plugins/cassandra_plugin.py#L174) - this bulks out our containers a bit, but I think it's the right approach from a maintainability point of view, in terms of making our Docker containers similar to the Clearwater nodes we test everywhere else.

I've tested both with docker-compose and the manual instructions, running clearwater-live-test after spinning up to make sure things are working. I've used my https://github.com/Metaswitch/clearwater-cassandra/pull/79 branch, which won't work (won't set up cassandra.yaml) unless clearwater-cluster-manager runs successfully.
