### PR TITLE
[Reviewer: Matt] Pin to release-92

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,7 +16,7 @@ ENV LC_ALL en_US.UTF-8
 COPY sysctl /sbin/sysctl
 RUN sed -e 's/\#\(precedence ::ffff:0:0\/96  100\)/\1/g' -i /etc/gai.conf
 
-RUN echo deb http://repo.cw-ngv.com/stable binary/ > /etc/apt/sources.list.d/clearwater.list
+RUN echo deb http://repo.cw-ngv.com/archive/repo92 binary/ > /etc/apt/sources.list.d/clearwater.list
 RUN curl -L http://repo.cw-ngv.com/repo_key | apt-key add -
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes clearwater-infrastructure clearwater-auto-config-docker
 RUN /etc/init.d/clearwater-auto-config-docker restart


### PR DESCRIPTION
This pins clearwater-docker to our last release. I think this is a temporary measure - it lets me merge https://github.com/Metaswitch/clearwater-cassandra/pull/79 now without breaking Docker, and means we can resolve your comment at https://github.com/Metaswitch/clearwater-docker/pull/19#discussion_r56764789 without time pressure.

Any objections?
