### PR TITLE
[No reviewer] Revert Compose v2 API changes to allow release-92 pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,12 @@ To prepare your system to deploy Clearwater manually, run:
 
 To start the Clearwater services, run:
 
-    sudo docker network create --driver bridge clearwater_nw
-    sudo docker run -d --net=clearwater_nw --name homestead -p 22 clearwater/homestead
-    sudo docker run -d --net=clearwater_nw --name homer -p 22 clearwater/homer
-    sudo docker run -d --net=clearwater_nw --name ralf -p 22 clearwater/ralf
-    sudo docker run -d --net=clearwater_nw --name sprout -p 22 clearwater/sprout
-    sudo docker run -d --net=clearwater_nw --name bono -p 22 -p 3478:3478 -p 3478:3478/udp -p 5060:5060 -p 5060:5060/udp -p 5062:5062 clearwater/bono
-    sudo docker run -d --net=clearwater_nw --name ellis -p 22 -p 80:80 clearwater/ellis
+    sudo docker run -d --name homestead -p 22 clearwater/homestead
+    sudo docker run -d --name homer -p 22 clearwater/homer
+    sudo docker run -d --name ralf -p 22 clearwater/ralf
+    sudo docker run -d --name sprout -p 22 --link homestead:homestead --link homer:homer --link ralf:ralf clearwater/sprout
+    sudo docker run -d --name bono -p 22 -p 3478:3478 -p 3478:3478/udp -p 5060:5060 -p 5060:5060/udp -p 5062:5062 --link sprout:sprout clearwater/bono
+    sudo docker run -d --name ellis -p 22 -p 80:80 --link homestead:homestead --link homer:homer clearwater/ellis
 
 ### Stopping Clearwater
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ To start the Clearwater services, run:
     sudo docker run -d --net=clearwater_nw --name bono -p 22 -p 3478:3478 -p 3478:3478/udp -p 5060:5060 -p 5060:5060/udp -p 5062:5062 clearwater/bono
     sudo docker run -d --net=clearwater_nw --name ellis -p 22 -p 80:80 clearwater/ellis
 
-The Clearwater Docker images use DNS for service discovery - they require, for example, that the name "ellis" should resolve to the Ellis container's IP address. In standard Docker, user-defined networks include [an embedded DNS server](https://docs.docker.com/engine/userguide/networking/dockernetworks/#docker-embedded-dns-server) which guarantees this (and this is why we create the clearwater_nw network) - and this type of DNS server is relatively common (for example, [Kubernetes provides something similar](http://kubernetes.io/docs/user-guide/services/#dns)).
-
 ### Stopping Clearwater
 
 To stop the Clearwater services, run:

--- a/minimal-distributed.yaml
+++ b/minimal-distributed.yaml
@@ -1,42 +1,39 @@
-version: '2'
-services:
-  bono:
-    build: bono
-    links:
-      - sprout
-    ports:
-      - 22
-      - "3478:3478"
-      - "3478:3478/udp"
-      - "5060:5060"
-      - "5060:5060/udp"
-      - "5062:5062"
-  sprout:
-    build: sprout
-    links:
-      - homestead
-      - homer
-      - ralf
-    ports:
-      - 22
-  homestead:
-    build: homestead
-    ports:
-      - 22
-  homer:
-    build: homer
-    ports:
-      - 22
-  ralf:
-    build: ralf
-    ports:
-      - 22
-  ellis:
-    build: ellis
-    links:
-      - homestead
-      - homer
-    ports:
-      - 22
-      - "80:80"
-
+bono:
+  build: bono
+  links:
+    - sprout
+  ports:
+    - 22
+    - "3478:3478"
+    - "3478:3478/udp"
+    - "5060:5060"
+    - "5060:5060/udp"
+    - "5062:5062"
+sprout:
+  build: sprout
+  links:
+    - homestead
+    - homer
+    - ralf
+  ports:
+    - 22
+homestead:
+  build: homestead
+  ports:
+    - 22
+homer:
+  build: homer
+  ports:
+    - 22
+ralf:
+  build: ralf
+  ports:
+    - 22
+ellis:
+  build: ellis
+  links:
+    - homestead
+    - homer
+  ports:
+    - 22
+    - "80:80"


### PR DESCRIPTION
This is because we're temporarily pinned to a release which doesn't have https://github.com/Metaswitch/clearwater-infrastructure/commit/5756cc42a503555a226fe17094361d38f5cb1108.
