### PR TITLE
[Reviewer: Matt] Run the docker install with sudo persimmons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There is a [Compose file](minimal-distributed.yaml) to instantiate a minimal (no
 To prepare your system to deploy Clearwater using compose, run:
 
     # Install Docker (on Ubuntu) - we need the latest for compatibility with Compose.
-    wget -qO- https://get.docker.com/ | sh
+    wget -qO- https://get.docker.com/ | sudo sh
 
     # Install Docker Compose (on Ubuntu).
     sudo apt-get install python-pip


### PR DESCRIPTION
Apt couldn't update without them.

Matt - is there a reason why I shouldn't recommend this?
