### PR TITLE
[Reviewer: AJL] Use split-storage package names

### DIFF
--- a/bono/Dockerfile
+++ b/bono/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes bono
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes bono-node
 RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \0/g' -i /etc/init.d/bono
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes restund

--- a/ellis/Dockerfile
+++ b/ellis/Dockerfile
@@ -2,7 +2,7 @@ FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes mysql-server
-RUN /etc/init.d/mysql start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes ellis
+RUN /etc/init.d/mysql start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes ellis-node
 RUN /etc/init.d/mysql start && /usr/share/clearwater/ellis/env/bin/python /usr/share/clearwater/ellis/src/metaswitch/ellis/tools/create_numbers.py --start 6505550000 --count 1000
 
 COPY ellis.supervisord.conf /etc/supervisor/conf.d/ellis.conf

--- a/homer/Dockerfile
+++ b/homer/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER maintainers@projectclearwater.org
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes clearwater-cassandra
 RUN sed -e 's/-user cassandra/-user root/g' -i /etc/init.d/cassandra
-RUN /etc/init.d/cassandra start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homer
+RUN /etc/init.d/cassandra start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homer-node
 
 COPY cassandra.supervisord.conf /etc/supervisor/conf.d/cassandra.conf
 COPY homer.supervisord.conf /etc/supervisor/conf.d/homer.conf

--- a/homestead/Dockerfile
+++ b/homestead/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER maintainers@projectclearwater.org
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes clearwater-cassandra
 RUN sed -e 's/-user cassandra/-user root/g' -i /etc/init.d/cassandra
 
-RUN /etc/init.d/cassandra start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead-node homestead-node-prov clearwater-prov-tools
+RUN /etc/init.d/cassandra start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead-node clearwater-prov-tools
 RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \1/g' -i /etc/init.d/homestead
 
 COPY cassandra.supervisord.conf /etc/supervisor/conf.d/cassandra.conf

--- a/homestead/Dockerfile
+++ b/homestead/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER maintainers@projectclearwater.org
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes clearwater-cassandra
 RUN sed -e 's/-user cassandra/-user root/g' -i /etc/init.d/cassandra
 
-RUN /etc/init.d/cassandra start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead homestead-prov clearwater-prov-tools
+RUN /etc/init.d/cassandra start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead-node homestead-node-prov clearwater-prov-tools
 RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \1/g' -i /etc/init.d/homestead
 
 COPY cassandra.supervisord.conf /etc/supervisor/conf.d/cassandra.conf

--- a/ralf/Dockerfile
+++ b/ralf/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes ralf
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes ralf-node
 RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \0/g' -i /etc/init.d/ralf
 
 COPY chronos.supervisord.conf /etc/supervisor/conf.d/chronos.conf

--- a/sprout/Dockerfile
+++ b/sprout/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes sprout
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes sprout-node
 RUN sed -e 's/\(echo 0 > \/proc\/sys\/kernel\/yama\/ptrace_scope\)/# \0/g' -i /etc/init.d/sprout
 
 COPY chronos.supervisord.conf /etc/supervisor/conf.d/chronos.conf


### PR DESCRIPTION
Again just rename the packages to the "-node" versions.
