### PR TITLE
For HS-prov, use poll_script instead of liveness check

### DIFF
--- a/kubernetes/homestead-prov-depl.yaml
+++ b/kubernetes/homestead-prov-depl.yaml
@@ -29,9 +29,9 @@ spec:
               fieldPath: status.podIP
         livenessProbe:
           exec:
-            command: ["/bin/bash", "/usr/share/kubernetes/liveness.sh", "8889"]
+            command: ["/bin/bash", "/usr/share/clearwater/bin/poll_homestead-prov.sh"]
           initialDelaySeconds: 60
         readinessProbe:
           exec:
-            command: ["/bin/bash", "/usr/share/kubernetes/liveness.sh", "8889"]
+            command: ["/bin/bash", "/usr/share/clearwater/bin/poll_homestead-prov.sh"]
       restartPolicy: Always


### PR DESCRIPTION
Because Nginx is listening on the port, not hs-prov, the liveness script was not working properly. This will correctly check if hs-prov process is up and running happily