### PR TITLE
Always pull latest images

### DIFF
--- a/kubernetes/astaire-depl.yaml
+++ b/kubernetes/astaire-depl.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/astaire:latest"
+        imagePullPolicy: Always
         name: astaire
         ports:
         - containerPort: 22

--- a/kubernetes/bono-depl.yaml
+++ b/kubernetes/bono-depl.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/bono:latest"
+        imagePullPolicy: Always
         name: bono
         ports:
         - containerPort: 22

--- a/kubernetes/cassandra-depl.yaml
+++ b/kubernetes/cassandra-depl.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/cassandra:latest"
+        imagePullPolicy: Always
         name: cassandra
         ports:
         - containerPort: 22

--- a/kubernetes/chronos-depl.yaml
+++ b/kubernetes/chronos-depl.yaml
@@ -13,6 +13,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/chronos:latest"
+        imagePullPolicy: Always
         name: chronos
         ports:
         - containerPort: 22

--- a/kubernetes/ellis-depl.yaml
+++ b/kubernetes/ellis-depl.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/ellis:latest"
+        imagePullPolicy: Always
         name: ellis
         ports:
         - containerPort: 22

--- a/kubernetes/homer-depl.yaml
+++ b/kubernetes/homer-depl.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/homer:latest"
+        imagePullPolicy: Always
         name: homer
         ports:
         - containerPort: 22

--- a/kubernetes/homestead-depl.yaml
+++ b/kubernetes/homestead-depl.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/homestead:latest"
+        imagePullPolicy: Always
         name: homestead
         ports:
         - containerPort: 22

--- a/kubernetes/homestead-prov-depl.yaml
+++ b/kubernetes/homestead-prov-depl.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/homestead-prov:latest"
+        imagePullPolicy: Always
         name: homestead-prov
         ports:
         - containerPort: 22

--- a/kubernetes/ralf-depl.yaml
+++ b/kubernetes/ralf-depl.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/ralf:latest"
+        imagePullPolicy: Always
         name: ralf
         ports:
         - containerPort: 22

--- a/kubernetes/sprout-depl.yaml
+++ b/kubernetes/sprout-depl.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       containers:
       - image: "{{REPO}}/clearwater/sprout:latest"
+        imagePullPolicy: Always
         name: sprout
         ports:
         - containerPort: 22


### PR DESCRIPTION
By default, K8s pulls new images every time if you are using ":latest".  But not if you are using anything else.   Fix that so that developers can use tags like ":mgm_latest"