### PR TITLE
[Reviewer: Mat] Setup the socket factory

### DIFF
--- a/bono/Dockerfile
+++ b/bono/Dockerfile
@@ -11,4 +11,7 @@ COPY bono.supervisord.conf /etc/supervisor/conf.d/bono.conf
 COPY restund.supervisord.conf /etc/supervisor/conf.d/restund.conf
 COPY clearwater-group.supervisord.conf /etc/supervisor/conf.d/clearwater-group.conf
 
+# We need to start the socket factories so that we can write to SAS.
+RUN cp /etc/clearwater/socket-factory.supervisord.conf /etc/supervisor/conf.d/
+
 EXPOSE 3478 3478/udp 5058 5060 5060/udp 5062


### PR DESCRIPTION
I was running some testing, and noticed Bono logs spamming about namespace sockets. Looked into why, and found the Dockerfile didn't have the lines i've added here, where e.g. sprout does.
Tested live and it seems to work as expected.