### PR TITLE
[Reviewer: Mat] Fix up ellis container build for non-aufs storage drivers

### DIFF
--- a/ellis/Dockerfile
+++ b/ellis/Dockerfile
@@ -2,8 +2,7 @@ FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes mysql-server
-RUN /etc/init.d/mysql start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes ellis
-RUN /etc/init.d/mysql start
+RUN find /var/lib/mysql -exec touch {} \; && /etc/init.d/mysql start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes ellis
 
 COPY create_numbers.sh /usr/share/clearwater/ellis/create_numbers.sh
 COPY ellis.supervisord.conf /etc/supervisor/conf.d/ellis.conf

--- a/ellis/Dockerfile
+++ b/ellis/Dockerfile
@@ -2,6 +2,10 @@ FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes mysql-server
+
+# mysql won't start on overlay or overlay2 storage drivers unless you touch the
+# files under /var/lib/msql first.
+# See https://github.com/docker/for-linux/issues/72#issuecomment-319904698
 RUN find /var/lib/mysql -exec touch {} \; && /etc/init.d/mysql start && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes ellis
 
 COPY create_numbers.sh /usr/share/clearwater/ellis/create_numbers.sh


### PR DESCRIPTION
mysql can't start on docker hosts running a non-aufs storage driver.
Touching all the files under /var/lib/mysql is a workaround for this.

I've tested that this fix resolves the ellis build issues we were seeing periodically (it turns out that it depends on the storage driver your docker host is using)