### PR TITLE
added option to authenticate with registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ Instead of using Docker Compose, you can deploy Clearwater in Kubernetes. This r
 
   e.g. `kubectl create configmap env-vars --from-literal=ZONE=default.svc.cluster.local --from-literal=ADDITIONAL_SHARED_CONFIG=hss_hostname=hss.example.com\\nhss_realm=example.com`
 
+- If you're using a private container registry (one that requires credentials to pull images from), create a secret with the required credentials. e.g. `kubectl create secret docker-registry myregistrykey --docker-server=$DOCKER_REGISTRY_SERVER --docker-username=$DOCKER_USER --docker-password=$DOCKER_PASSWORD --docker-email=$DOCKER_EMAIL`
 - Update the Kubernetes yaml to match your deployment.
 
   - Generate the Kubernetes yaml files from the templates by going to the kubernetes directory and running `./k8s-gencfg --image_path=<path to your repo> --image_tag=<tag for the images you want to use>`
+    If you're using a private container registry, add the argument `--image_secret=myregistrykey` (where `myregistrykey` matches the secret you made earlier)
     The script assumes that the Clearwater images that you want to use are located at {{image_path}}/\<image name e.g. bono\>:{{image_tag}}. It will also generate a helm chart in `/kubernetes/clearwater`.
 
   - Decide how you want to access Bono and Ellis from outside of the cluster.

--- a/homestead-prov/Dockerfile
+++ b/homestead-prov/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead-prov clearwater-prov-tools
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead homestead-prov clearwater-prov-tools
 
 COPY homestead-prov.supervisord.conf /etc/supervisor/conf.d/homestead-prov.conf
 COPY nginx.supervisord.conf /etc/supervisor/conf.d/nginx.conf

--- a/homestead-prov/Dockerfile
+++ b/homestead-prov/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead homestead-prov clearwater-prov-tools
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead-prov clearwater-prov-tools
 
 COPY homestead-prov.supervisord.conf /etc/supervisor/conf.d/homestead-prov.conf
 COPY nginx.supervisord.conf /etc/supervisor/conf.d/nginx.conf

--- a/kubernetes/k8s-gencfg
+++ b/kubernetes/k8s-gencfg
@@ -12,15 +12,11 @@ def parse_file(args, input_file, output_file):
     with open(input_file) as file:
         input_data = file.read()
 
-    data = input_data.replace("{{IMAGE_PATH}}", args.image_path)
-    data = data.replace("{{IMAGE_TAG}}", args.image_tag)
-
-    # this argument is optional
+    # IMAGE_SECRET is an optional argument
     # ~ means null in yaml
-    output_data = data.replace("{{IMAGE_SECRET}}", args.image_secret if (args.image_secret != None) else "~")
-
-
-        
+    output_data = input_data.replace("{{IMAGE_PATH}}", args.image_path) \
+                  .replace("{{IMAGE_TAG}}", args.image_tag) \
+                  .replace("{{IMAGE_SECRET}}", args.image_secret if (args.image_secret != None) else "~") 
 
     with open(output_file, "w") as file:
         file.write(output_data)

--- a/kubernetes/k8s-gencfg
+++ b/kubernetes/k8s-gencfg
@@ -12,7 +12,15 @@ def parse_file(args, input_file, output_file):
     with open(input_file) as file:
         input_data = file.read()
 
-    output_data = input_data.replace("{{IMAGE_PATH}}", args.image_path).replace("{{IMAGE_TAG}}", args.image_tag)
+    data = input_data.replace("{{IMAGE_PATH}}", args.image_path)
+    data = data.replace("{{IMAGE_TAG}}", args.image_tag)
+
+    # this argument is optional
+    # ~ means null in yaml
+    output_data = data.replace("{{IMAGE_SECRET}}", args.image_secret if (args.image_secret != None) else "~")
+
+
+        
 
     with open(output_file, "w") as file:
         file.write(output_data)
@@ -27,6 +35,7 @@ def parse_files_in_dir(args, src, dest):
 
         parse_file(args, os.path.join(src, template_file_name), os.path.join(dest, template_name+".yaml"))
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -35,6 +44,9 @@ if __name__ == '__main__':
     parser.add_argument(
             '--image_tag', required=True, 
             help='The image tag to use')
+    parser.add_argument(
+            '--image_secret', required=False, 
+            help='(Optional) The kubernetes secret for authenticating with the container registry')
     args = parser.parse_args()
 
     # Create kubernetes manifests

--- a/kubernetes/templates/astaire-depl.tmpl
+++ b/kubernetes/templates/astaire-depl.tmpl
@@ -50,4 +50,6 @@ spec:
       volumes:
       - name: astairelogs
         emptyDir: {}
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/bono-depl.tmpl
+++ b/kubernetes/templates/bono-depl.tmpl
@@ -60,4 +60,6 @@ spec:
       volumes:
       - name: bonologs
         emptyDir: {}
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/cassandra-depl.tmpl
+++ b/kubernetes/templates/cassandra-depl.tmpl
@@ -34,4 +34,6 @@ spec:
         readinessProbe:
           exec:
             command: ["/bin/bash", "/usr/share/kubernetes/liveness.sh", "7000 9042 9160"]
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/chronos-depl.tmpl
+++ b/kubernetes/templates/chronos-depl.tmpl
@@ -51,4 +51,6 @@ spec:
       volumes:
       - name: chronoslogs
         emptyDir: {}
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/ellis-depl.tmpl
+++ b/kubernetes/templates/ellis-depl.tmpl
@@ -31,4 +31,6 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 80
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/etcd-depl.tmpl
+++ b/kubernetes/templates/etcd-depl.tmpl
@@ -55,4 +55,6 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 4001
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/homer-depl.tmpl
+++ b/kubernetes/templates/homer-depl.tmpl
@@ -31,4 +31,6 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 7888
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/homestead-depl.tmpl
+++ b/kubernetes/templates/homestead-depl.tmpl
@@ -47,4 +47,6 @@ spec:
       volumes:
       - name: homesteadlogs
         emptyDir: {}
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/homestead-prov-depl.tmpl
+++ b/kubernetes/templates/homestead-prov-depl.tmpl
@@ -35,4 +35,6 @@ spec:
         readinessProbe:
           exec:
             command: ["/bin/bash", "/usr/share/clearwater/bin/poll_homestead-prov.sh"]
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/ralf-depl.tmpl
+++ b/kubernetes/templates/ralf-depl.tmpl
@@ -47,4 +47,6 @@ spec:
       volumes:
       - name: ralflogs
         emptyDir: {}
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always

--- a/kubernetes/templates/sprout-depl.tmpl
+++ b/kubernetes/templates/sprout-depl.tmpl
@@ -47,4 +47,6 @@ spec:
       volumes:
       - name: sproutlogs
         emptyDir: {}
+      imagePullSecrets:
+      - name: {{IMAGE_SECRET}}
       restartPolicy: Always


### PR DESCRIPTION
If you use a private container registry, you need to add a parameter to each yaml file. Doing that manually is a pain, so I added it to `k8s-gencfg`.

Since we're not using a full template library, I found it easiest to leave the new parameter in the yaml files even if you don't need it, and just set it to `~` (yaml null).
I don't have a public registry to test with, so it would be good if someone else can double check that `~` works when you don't need to authenticate. It is valid yaml, so I expect it to work.