### PR TITLE
Fixed missing file issue with homestead-prov

### DIFF
--- a/homestead-prov/Dockerfile
+++ b/homestead-prov/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead homestead-prov clearwater-prov-tools
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes clearwater-socket-factory homestead-prov clearwater-prov-tools
 
 COPY homestead-prov.supervisord.conf /etc/supervisor/conf.d/homestead-prov.conf
 COPY nginx.supervisord.conf /etc/supervisor/conf.d/nginx.conf

--- a/homestead-prov/Dockerfile
+++ b/homestead-prov/Dockerfile
@@ -1,7 +1,7 @@
 FROM clearwater/base
 MAINTAINER maintainers@projectclearwater.org
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead-prov clearwater-prov-tools
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes homestead homestead-prov clearwater-prov-tools
 
 COPY homestead-prov.supervisord.conf /etc/supervisor/conf.d/homestead-prov.conf
 COPY nginx.supervisord.conf /etc/supervisor/conf.d/nginx.conf


### PR DESCRIPTION
There was a bug in homestead-prov. [Here is my mailing list email](http://lists.projectclearwater.org/pipermail/clearwater_lists.projectclearwater.org/2018-May/003935.html) about it. I think it's also what is described in #70 .

The issue was that when homestead-prov spins up, it tries to find two files which aren't there.

* `/usr/share/clearwater/bin/clearwater-socket-factory-mgmt-wrapper`
* `/usr/share/clearwater/bin/clearwater-socket-factory-sig-wrapper`

This bug was introduced when homestead-prov was split off from homestead. The solution is to do `apt-get install homestead` when building the `homestead-prov` pod.

I still can't get homestead and homestead-prov to spin up. There's still some other issue. But this patch helps fix the first issue. 